### PR TITLE
Fix $PWD handling

### DIFF
--- a/helix-wezterm.sh
+++ b/helix-wezterm.sh
@@ -21,7 +21,7 @@ split_pane_down() {
   fi
 }
 
-pwd=$(PWD)
+pwd=$PWD
 basedir=$(dirname "$filename")
 basename=$(basename "$filename")
 basename_without_extension="${basename%.*}"
@@ -68,7 +68,7 @@ case "$1" in
     if [ "$program" = "lazygit" ]; then
         wezterm cli activate-pane-direction down
     else
-        echo "lazygit" | $send_to_bottom_pane
+        echo "cd $pwd; lazygit" | $send_to_bottom_pane
     fi
     ;;
   "open")


### PR DESCRIPTION
Mishandling of the current directory was causing some commands to fail:

- $(PWD) would have returned a command named "PWD" in a subshell and returned nothing.
-  lazygit was missing a cd to the current directory.

I did not check all the commands to see if they also needed updated directory handling.