### PR TITLE
drop envsubst dep

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,6 @@ The available values for the position are `window`, `tab`, `top`, `bottom`, `lef
 
 Install the following requirements:
 
-- [envsubst](https://www.gnu.org/software/gettext/manual/html_node/envsubst-Invocation.html)
 - [yq](https://github.com/mikefarah/yq) *(Ensure that you are using the `yq` implementation written in Golang, not the one [written in Python](https://github.com/kislyuk/yq))*
 
 Additionally, it's recommended to install the following CLI tools:

--- a/helix-wezterm.sh
+++ b/helix-wezterm.sh
@@ -155,6 +155,5 @@ if [ "$act" != "null" ]; then
     command=$(yq e ".actions.$action.extensions.$extension" "$config_file")
   fi
 
-  expanded_command=$(echo $command | envsubst '$WEZTERM_PANE,$basedir,$binary_output,$buffer_name,$cursor_line,$interface_name,$test_name,$session,$entry')
-  echo "$expanded_command\r" | $send_to_pane
+  eval echo "$command\r" | $send_to_pane
 fi


### PR DESCRIPTION
The envsubst command is often not installed by default on minimal distros.

However, the same result can be accomplished by calling a shell `eval` command
which will cause the command to be evaluated with all the currently set environment
variables considered.

This change has not been tested yet.
